### PR TITLE
Limit the scope of keycommands to tidal documents

### DIFF
--- a/keymaps/tidal.json
+++ b/keymaps/tidal.json
@@ -1,5 +1,5 @@
 {
-    "atom-workspace atom-text-editor:not(.mini)": {
+    "atom-workspace atom-text-editor[data-grammar~='tidal']": {
         "shift-enter": "tidalcycles:eval",
         "alt-shift-enter": "tidalcycles:eval-copy",
         "cmd-enter": "tidalcycles:eval-multi-line",


### PR DESCRIPTION
This was breaking atom-supercollider. 

shift-enter would get handled by tidal even on supercollider .scd documents.

I am also changing atom-supercollider in the same way to limit to data-grammar~='supercollider'

:not(.mini) isn't really required I think.