### PR TITLE
eval-all-lines command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 ## 0.1.0 - First Release
 * Every feature added
 * Every bug fixed
+
+## 0.8.4 - Fix for .tidal files
+* fixed issue with TidalCycles commands firing even in non-.tidal files
+
+## 0.8.5 - Eval All Lines
+* added support for eval'ing _all_ lines at once in the editor with `cmd+shift+enter`

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ For installation instructions, please visit:
 
 Then, you can:
   * Open a `.tidal` file
-  
+
   * `shift+enter` to evaluate the current line or selection
 
   * `cmd+enter` to evaluate multiple-lines or selection
+
+  * `cmd+shift+enter` to evaluate all text in the editor at once (proper indenting required)
 
 To send patterns to [SuperDirt](https://github.com/musikinformatik/SuperDirt), use `d1` .. `d9`, e.g.:
 

--- a/keymaps/tidal.json
+++ b/keymaps/tidal.json
@@ -4,6 +4,8 @@
         "alt-shift-enter": "tidalcycles:eval-copy",
         "cmd-enter": "tidalcycles:eval-multi-line",
         "ctrl-enter": "tidalcycles:eval-multi-line",
+        "cmd-shift-enter": "tidalcycles:eval-all-lines",
+        "ctrl-shift-enter": "tidalcycles:eval-all-lines",
         "alt-cmd-enter": "tidalcycles:eval-multi-line-copy",
         "shift-cmd-h": "tidalcycles:hush"
     }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -2,10 +2,11 @@
 
 var fs = require('fs');
 var spawn = require('child_process').spawn;
-var Range = require('atom').range;
-var bootFilePath = __dirname + "/BootTidal.hs"
-var CONST_LINE = 'line'
-var CONST_MULTI_LINE = 'multi_line'
+var Range = require('atom').Range;
+var bootFilePath = __dirname + "/BootTidal.hs";
+var CONST_LINE = 'line';
+var CONST_MULTI_LINE = 'multi_line';
+var CONST_ALL_LINES = 'all_lines';
 
 export default class REPL {
 
@@ -28,6 +29,7 @@ export default class REPL {
         atom.commands.add('atom-text-editor', {
             'tidalcycles:eval': () => this.eval(CONST_LINE, false),
             'tidalcycles:eval-multi-line': () => this.eval(CONST_MULTI_LINE, false),
+            'tidalcycles:eval-all-lines': () => this.eval(CONST_ALL_LINES, false),
             'tidalcycles:eval-copy': () => this.eval(CONST_LINE, true),
             'tidalcycles:eval-multi-line-copy': () => this.eval(CONST_MULTI_LINE, true),
             'tidalcycles:hush': () => this.hush()
@@ -101,10 +103,41 @@ export default class REPL {
 
         if (!this.repl) this.start();
 
-        var expressionAndRange = this.currentExpression(evalType);
-        var expression = expressionAndRange[0];
-        var range = expressionAndRange[1];
-        this.evalWithRepl(expression, range, copy);
+        if (evalType === CONST_ALL_LINES){
+          this.evalAllLines();
+        } else {
+          this.evalExpression(evalType, copy);
+        }
+    }
+
+    evalAllLines(){
+        console.log('evaluating all lines');
+
+        var editor = this.getEditor();
+        if (!editor) return;
+
+        var allText = editor.getText();
+        var lineCount = editor.buffer.lines.length;
+        var flashRange = new Range([0,0],[lineCount,0]);
+        var doText = this.replaceAll(`do\n${allText}`, '\n', '\n   ');
+
+        console.log(doText);
+        this.evalWithRepl(doText, flashRange, false);
+    }
+
+    escapeRegExp(str) {
+      return str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+    }
+
+    replaceAll(str, find, replace) {
+      return str.replace(new RegExp(this.escapeRegExp(find), 'g'), replace);
+    }
+
+    evalExpression(evalType, copy){
+      var expressionAndRange = this.currentExpression(evalType);
+      var expression = expressionAndRange[0];
+      var range = expressionAndRange[1];
+      this.evalWithRepl(expression, range, copy);
     }
 
     evalWithRepl(expression, range, copy) {
@@ -125,7 +158,7 @@ export default class REPL {
                 if (unflash) {
                     unflash('eval-success');
                 }
-            }          
+            }
 
             self.tidalSendExpression(expression);
             onSuccess();

--- a/menus/tidalcycles.json
+++ b/menus/tidalcycles.json
@@ -22,6 +22,9 @@
                 "label": "Eval Multi Line And Copy",
                 "command": "tidalcycles:eval-multi-line-copy"
             }, {
+                    "label": "Eval All Lines",
+                    "command": "tidalcycles:eval-all-lines"
+            }, {
                 "label": "Hush",
                 "command": "tidalcycles:hush"
             }]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "activationCommands": {
     "atom-text-editor": [
       "tidalcycles:eval",
-      "tidalcycles:eval-multi-line"
+      "tidalcycles:eval-multi-line",
+      "tidalcycles:eval-all-lines"
     ],
     "atom-workspace": "tidalcycles:boot"
   },


### PR DESCRIPTION
This adds support to eval **all** lines in the buffer. New keyboard command is `cmd+shift+enter`. Behind the scenes, it will wrap all of the buffer code in a `do` and add some indenting before sending it to `ghci`.

e.g. it will take this:

```
d1 $ sound "bd sn"

d2 $ sound "arpy*8?"
```

and convert it to this when sending to `ghci`:

```
do
   d1 $ sound "bd sn"

   d2 $ sound "arpy*8?"
```

User's editor is not affected. The `do` and indenting only happen behind the scenes.