### PR TITLE
eval multiple statements/blocks in one command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@
 
 ## 0.8.5 - Eval All Lines
 * added support for eval'ing _all_ lines at once in the editor with `cmd+shift+enter`
+* can now eval multiple adjacent SuperDirt/Dirt blocks with the `multiline` eval command
+* additional keymap for hush: `ctrl+shift+h`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,6 @@
 * fixed issue with TidalCycles commands firing even in non-.tidal files
 
 ## 0.8.5 - Eval All Lines
-* added support for eval'ing _all_ lines at once in the editor with `cmd+shift+enter`
-* can now eval multiple adjacent SuperDirt/Dirt blocks with the `multiline` eval command
-* additional keymap for hush: `ctrl+shift+h`
+* eval _all_ lines at once in the editor (indenting required)
+* eval multiple adjacent blocks with the `multiline` eval command (indenting required)
+* new keymap for hush: `ctrl+.`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 ## 0.1.0 - First Release
 * Every feature added
 * Every bug fixed
+
+## 0.8.4 - Fix for .tidal files
+* fixed issue with TidalCycles commands firing even in non-.tidal files
+
+## 0.8.5 - Eval All Lines
+* added support for eval'ing _all_ lines at once in the editor with `cmd+shift+enter`

--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ For installation instructions, please visit:
 
 Then, you can:
   * Open a `.tidal` file
-  
+
   * `shift+enter` to evaluate the current line or selection
 
   * `cmd+enter` to evaluate multiple-lines or selection
+
+  * `cmd+shift+enter` to evaluate all text in the editor at once (proper indenting required)
 
 To send patterns to [SuperDirt](https://github.com/musikinformatik/SuperDirt), use `d1` .. `d9`, e.g.:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Then, you can:
 
   * `cmd+enter` to evaluate multiple-lines or selection
 
-  * `cmd+shift+enter` to evaluate all text in the editor at once (proper indenting required)
+  * `cmd+shift+space` to evaluate all text in the editor at once (proper indenting required)
 
 To send patterns to [SuperDirt](https://github.com/musikinformatik/SuperDirt), use `d1` .. `d9`, e.g.:
 

--- a/keymaps/tidal.json
+++ b/keymaps/tidal.json
@@ -7,6 +7,7 @@
         "cmd-shift-enter": "tidalcycles:eval-all-lines",
         "ctrl-shift-enter": "tidalcycles:eval-all-lines",
         "alt-cmd-enter": "tidalcycles:eval-multi-line-copy",
-        "shift-cmd-h": "tidalcycles:hush"
+        "shift-cmd-h": "tidalcycles:hush",
+        "ctrl-shift-h": "tidalcycles:hush"
     }
 }

--- a/keymaps/tidal.json
+++ b/keymaps/tidal.json
@@ -4,9 +4,12 @@
         "alt-shift-enter": "tidalcycles:eval-copy",
         "cmd-enter": "tidalcycles:eval-multi-line",
         "ctrl-enter": "tidalcycles:eval-multi-line",
-        "cmd-shift-enter": "tidalcycles:eval-all-lines",
-        "ctrl-shift-enter": "tidalcycles:eval-all-lines",
+        "cmd-shift-enter": "tidalcycles:eval-multi-line-multi-block",
+        "ctrl-shift-enter": "tidalcycles:eval-multi-line-multi-block",
+        "cmd-shift-space": "tidalcycles:eval-all-lines",
+        "ctrl-shift-space": "tidalcycles:eval-all-lines",
         "alt-cmd-enter": "tidalcycles:eval-multi-line-copy",
+        "alt-ctrl-enter": "tidalcycles:eval-multi-line-copy",
         "shift-cmd-h": "tidalcycles:hush",
         "ctrl-.": "tidalcycles:hush"
     }

--- a/keymaps/tidal.json
+++ b/keymaps/tidal.json
@@ -4,6 +4,8 @@
         "alt-shift-enter": "tidalcycles:eval-copy",
         "cmd-enter": "tidalcycles:eval-multi-line",
         "ctrl-enter": "tidalcycles:eval-multi-line",
+        "cmd-shift-enter": "tidalcycles:eval-all-lines",
+        "ctrl-shift-enter": "tidalcycles:eval-all-lines",
         "alt-cmd-enter": "tidalcycles:eval-multi-line-copy",
         "shift-cmd-h": "tidalcycles:hush"
     }

--- a/keymaps/tidal.json
+++ b/keymaps/tidal.json
@@ -8,6 +8,6 @@
         "ctrl-shift-enter": "tidalcycles:eval-all-lines",
         "alt-cmd-enter": "tidalcycles:eval-multi-line-copy",
         "shift-cmd-h": "tidalcycles:hush",
-        "ctrl-shift-h": "tidalcycles:hush"
+        "ctrl-.": "tidalcycles:hush"
     }
 }

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -2,10 +2,11 @@
 
 var fs = require('fs');
 var spawn = require('child_process').spawn;
-var Range = require('atom').range;
-var bootFilePath = __dirname + "/BootTidal.hs"
-var CONST_LINE = 'line'
-var CONST_MULTI_LINE = 'multi_line'
+var Range = require('atom').Range;
+var bootFilePath = __dirname + "/BootTidal.hs";
+var CONST_LINE = 'line';
+var CONST_MULTI_LINE = 'multi_line';
+var CONST_ALL_LINES = 'all_lines';
 
 export default class REPL {
 
@@ -28,6 +29,7 @@ export default class REPL {
         atom.commands.add('atom-text-editor', {
             'tidalcycles:eval': () => this.eval(CONST_LINE, false),
             'tidalcycles:eval-multi-line': () => this.eval(CONST_MULTI_LINE, false),
+            'tidalcycles:eval-all-lines': () => this.eval(CONST_ALL_LINES, false),
             'tidalcycles:eval-copy': () => this.eval(CONST_LINE, true),
             'tidalcycles:eval-multi-line-copy': () => this.eval(CONST_MULTI_LINE, true),
             'tidalcycles:hush': () => this.hush()
@@ -101,10 +103,41 @@ export default class REPL {
 
         if (!this.repl) this.start();
 
-        var expressionAndRange = this.currentExpression(evalType);
-        var expression = expressionAndRange[0];
-        var range = expressionAndRange[1];
-        this.evalWithRepl(expression, range, copy);
+        if (evalType === CONST_ALL_LINES){
+          this.evalAllLines();
+        } else {
+          this.evalExpression(evalType, copy);
+        }
+    }
+
+    evalAllLines(){
+        console.log('evaluating all lines');
+
+        var editor = this.getEditor();
+        if (!editor) return;
+
+        var allText = editor.getText();
+        var lineCount = editor.buffer.lines.length;
+        var flashRange = new Range([0,0],[lineCount,0]);
+        var doText = this.replaceAll(`do\n${allText}`, '\n', '\n   ');
+
+        console.log(doText);
+        this.evalWithRepl(doText, flashRange, false);
+    }
+
+    escapeRegExp(str) {
+      return str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+    }
+
+    replaceAll(str, find, replace) {
+      return str.replace(new RegExp(this.escapeRegExp(find), 'g'), replace);
+    }
+
+    evalExpression(evalType, copy){
+      var expressionAndRange = this.currentExpression(evalType);
+      var expression = expressionAndRange[0];
+      var range = expressionAndRange[1];
+      this.evalWithRepl(expression, range, copy);
     }
 
     evalWithRepl(expression, range, copy) {
@@ -125,7 +158,7 @@ export default class REPL {
                 if (unflash) {
                     unflash('eval-success');
                 }
-            }          
+            }
 
             self.tidalSendExpression(expression);
             onSuccess();

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -120,7 +120,7 @@ export default class REPL {
 
     evalExpression(evalType, copy){
       var expressionAndRange = this.currentExpression(evalType);
-      var expression = this.wrapInDo(expressionAndRange[0]);
+      var expression = expressionAndRange[0];
       var range = expressionAndRange[1];
 
       this.evalWithRepl(expression, range, copy);
@@ -202,12 +202,12 @@ export default class REPL {
 
     getMultiLineExpression(editor) {
         var range = editor.getCurrentParagraphBufferRange();
-        var expression = editor.getTextInBufferRange(range);
+        var expression = this.wrapInDo(editor.getTextInBufferRange(range));
         return [expression, range];
     }
 
     getAllLinesExpression(editor){
-      var expression = editor.getText();
+      var expression = this.wrapInDo(editor.getText());
       var lineCount = editor.buffer.lines.length;
       var range = new Range([0,0],[lineCount,0]);
       return [expression, range];

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -6,6 +6,7 @@ var Range = require('atom').Range;
 var bootFilePath = __dirname + "/BootTidal.hs";
 var CONST_LINE = 'line';
 var CONST_MULTI_LINE = 'multi_line';
+var CONST_MULTI_LINE_MULTI_BLOCK = 'multi_line_multi_block';
 var CONST_ALL_LINES = 'all_lines';
 
 export default class REPL {
@@ -29,6 +30,7 @@ export default class REPL {
         atom.commands.add('atom-text-editor', {
             'tidalcycles:eval': () => this.eval(CONST_LINE, false),
             'tidalcycles:eval-multi-line': () => this.eval(CONST_MULTI_LINE, false),
+            'tidalcycles:eval-multi-line-multi-block': () => this.eval(CONST_MULTI_LINE_MULTI_BLOCK, false),
             'tidalcycles:eval-all-lines': () => this.eval(CONST_ALL_LINES, false),
             'tidalcycles:eval-copy': () => this.eval(CONST_LINE, true),
             'tidalcycles:eval-multi-line-copy': () => this.eval(CONST_MULTI_LINE, true),
@@ -79,10 +81,14 @@ export default class REPL {
         this.stdinWrite('\n');
     }
 
-    tidalSendExpression(expression) {
-        console.log(expression);
+    tidalSendExpression(expression, evalType) {
+        var expressionToSend = (evalType === CONST_MULTI_LINE_MULTI_BLOCK ||
+          evalType === CONST_ALL_LINES) ? this.wrapInDo(expression) : expression;
+
+        console.log(expressionToSend);
+
         this.tidalSendLine(':{');
-        var splits = expression.split('\n');
+        var splits = expressionToSend.split('\n');
         for (var i = 0; i < splits.length; i++) {
             this.tidalSendLine(splits[i]);
         }
@@ -123,10 +129,10 @@ export default class REPL {
       var expression = expressionAndRange[0];
       var range = expressionAndRange[1];
 
-      this.evalWithRepl(expression, range, copy);
+      this.evalWithRepl(expression, range, copy, evalType);
     }
 
-    evalWithRepl(expression, range, copy) {
+    evalWithRepl(expression, range, copy, evalType) {
         var self = this;
         if (!expression) return;
 
@@ -146,7 +152,7 @@ export default class REPL {
                 }
             }
 
-            self.tidalSendExpression(expression);
+            self.tidalSendExpression(expression, evalType);
             onSuccess();
         }
 
@@ -172,8 +178,8 @@ export default class REPL {
         } else {
             if (evalType === CONST_LINE) {
                 return this.getLineExpression(editor);
-            } else if (evalType === CONST_MULTI_LINE) {
-              return this.getMultiLineExpression(editor);
+            } else if (evalType === CONST_MULTI_LINE || evalType === CONST_MULTI_LINE_MULTI_BLOCK) {
+                return this.getMultiLineExpression(editor);
             }
             return this.getAllLinesExpression(editor);
         }
@@ -203,24 +209,11 @@ export default class REPL {
     getMultiLineExpression(editor) {
         var range = editor.getCurrentParagraphBufferRange();
         var expression = editor.getTextInBufferRange(range);
-
-        var lines = expression.split('\n');
-        var nonWhitespaceColZeros = 0;
-        for (var i = 0; i < lines.length; i++){
-          if (lines[i].charAt(0) !== ' '){
-            nonWhitespaceColZeros++;
-          }
-        }
-
-        if (nonWhitespaceColZeros > 1){
-          expression = this.wrapInDo(expression);
-        }
-
         return [expression, range];
     }
 
     getAllLinesExpression(editor){
-      var expression = this.wrapInDo(editor.getText());
+      var expression = editor.getText();
       var lineCount = editor.buffer.lines.length;
       var range = new Range([0,0],[lineCount,0]);
       return [expression, range];

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -80,6 +80,7 @@ export default class REPL {
     }
 
     tidalSendExpression(expression) {
+        console.log(expression);
         this.tidalSendLine(':{');
         var splits = expression.split('\n');
         for (var i = 0; i < splits.length; i++) {
@@ -93,6 +94,7 @@ export default class REPL {
         this.doSpawn();
         this.initTidal();
     }
+
     getEditor() {
         var editor = atom.workspace.getActiveTextEditor();
         return editor;
@@ -100,29 +102,12 @@ export default class REPL {
 
     eval(evalType, copy) {
         if (!this.editorIsTidal()) return;
-
         if (!this.repl) this.start();
-
-        if (evalType === CONST_ALL_LINES){
-          this.evalAllLines();
-        } else {
-          this.evalExpression(evalType, copy);
-        }
+        this.evalExpression(evalType, copy);
     }
 
-    evalAllLines(){
-        console.log('evaluating all lines');
-
-        var editor = this.getEditor();
-        if (!editor) return;
-
-        var allText = editor.getText();
-        var lineCount = editor.buffer.lines.length;
-        var flashRange = new Range([0,0],[lineCount,0]);
-        var doText = this.replaceAll(`do\n${allText}`, '\n', '\n   ');
-
-        console.log(doText);
-        this.evalWithRepl(doText, flashRange, false);
+    wrapInDo(expression){
+      return this.replaceAll(`do\n${expression}`, '\n', '\n   ');
     }
 
     escapeRegExp(str) {
@@ -135,8 +120,9 @@ export default class REPL {
 
     evalExpression(evalType, copy){
       var expressionAndRange = this.currentExpression(evalType);
-      var expression = expressionAndRange[0];
+      var expression = this.wrapInDo(expressionAndRange[0]);
       var range = expressionAndRange[1];
+
       this.evalWithRepl(expression, range, copy);
     }
 
@@ -186,8 +172,10 @@ export default class REPL {
         } else {
             if (evalType === CONST_LINE) {
                 return this.getLineExpression(editor);
+            } else if (evalType === CONST_MULTI_LINE) {
+              return this.getMultiLineExpression(editor);
             }
-            return this.getMultiLineExpression(editor);
+            return this.getAllLinesExpression(editor);
         }
     }
 
@@ -216,6 +204,13 @@ export default class REPL {
         var range = editor.getCurrentParagraphBufferRange();
         var expression = editor.getTextInBufferRange(range);
         return [expression, range];
+    }
+
+    getAllLinesExpression(editor){
+      var expression = editor.getText();
+      var lineCount = editor.buffer.lines.length;
+      var range = new Range([0,0],[lineCount,0]);
+      return [expression, range];
     }
 
     evalFlash(range) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -202,7 +202,20 @@ export default class REPL {
 
     getMultiLineExpression(editor) {
         var range = editor.getCurrentParagraphBufferRange();
-        var expression = this.wrapInDo(editor.getTextInBufferRange(range));
+        var expression = editor.getTextInBufferRange(range);
+
+        var lines = expression.split('\n');
+        var nonWhitespaceColZeros = 0;
+        for (var i = 0; i < lines.length; i++){
+          if (lines[i].charAt(0) !== ' '){
+            nonWhitespaceColZeros++;
+          }
+        }
+
+        if (nonWhitespaceColZeros > 1){
+          expression = this.wrapInDo(expression);
+        }
+
         return [expression, range];
     }
 

--- a/menus/tidalcycles.json
+++ b/menus/tidalcycles.json
@@ -19,11 +19,14 @@
                 "label": "Eval Multi Line",
                 "command": "tidalcycles:eval-multi-line"
             }, {
+                "label": "Eval Multi Line, Multi Block",
+                "command": "tidalcycles:eval-multi-line-multi-block"
+            }, {
                 "label": "Eval Multi Line And Copy",
                 "command": "tidalcycles:eval-multi-line-copy"
             }, {
-                    "label": "Eval All Lines",
-                    "command": "tidalcycles:eval-all-lines"
+                "label": "Eval All Lines",
+                "command": "tidalcycles:eval-all-lines"
             }, {
                 "label": "Hush",
                 "command": "tidalcycles:hush"

--- a/menus/tidalcycles.json
+++ b/menus/tidalcycles.json
@@ -22,6 +22,9 @@
                 "label": "Eval Multi Line And Copy",
                 "command": "tidalcycles:eval-multi-line-copy"
             }, {
+                    "label": "Eval All Lines",
+                    "command": "tidalcycles:eval-all-lines"
+            }, {
                 "label": "Hush",
                 "command": "tidalcycles:hush"
             }]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "activationCommands": {
     "atom-text-editor": [
       "tidalcycles:eval",
-      "tidalcycles:eval-multi-line"
+      "tidalcycles:eval-multi-line",
+      "tidalcycles:eval-all-lines"
     ],
     "atom-workspace": "tidalcycles:boot"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "atom-text-editor": [
       "tidalcycles:eval",
       "tidalcycles:eval-multi-line",
+      "tidalcycles:eval-multi-line-multi-block",
       "tidalcycles:eval-all-lines"
     ],
     "atom-workspace": "tidalcycles:boot"


### PR DESCRIPTION
Wrapped **all** expressions sent to `ghci` in a `do`. This now allows two things:

1. Eval all text in the buffer, which may include many Dirt/SuperDirt patterns, and send them all to `ghci` at once

2. Perform a multi-line eval on two or more adjacent patterns (with no empty lines between them).