### PR TITLE
Add nudge function to startup

### DIFF
--- a/lib/BootTidal.hs
+++ b/lib/BootTidal.hs
@@ -1,7 +1,7 @@
 :set prompt ""
 :module Sound.Tidal.Context
 
-(cps, getNow) <- bpsUtils
+(cps, nudge, getNow) <- cpsUtils'
 
 (c1,ct1) <- dirtSetters getNow
 (c2,ct2) <- dirtSetters getNow


### PR DESCRIPTION
The `nudge` function adjusts the current cycle count.

I believe this requires Tidal version >= 0.9.  Maybe it would be better to have Atom do some kind of version testing to see if `cpsUtils'` is available, and fall back to `cpsUtils` for people who still use older versions of Tidal?