### PR TITLE
Add settings file for editor:toggle-line-comments

### DIFF
--- a/settings/tidal.cson
+++ b/settings/tidal.cson
@@ -1,0 +1,3 @@
+'.source.tidalcycles':
+  'editor':
+    'commentStart': '-- '


### PR DESCRIPTION
This PR enables `editor:toggle-line-comments`  by `Cmd-/`.

### before
It wraps selected lines with `/* */`.
![before](https://user-images.githubusercontent.com/1403842/27573014-6fdc4508-5b4a-11e7-8952-28d779cc1b54.gif)

### after
It appends `-- ` at the beginning of selected lines.
![after](https://user-images.githubusercontent.com/1403842/27573019-75d78404-5b4a-11e7-9f44-2af685624b97.gif)
