### PR TITLE
Eval multiline expression including comments

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -180,9 +180,26 @@ export default class REPL {
     }
 
     getMultiLineExpression(editor) {
-        var range = editor.getCurrentParagraphBufferRange();
+        var range = this.getCurrentParagraphIncludingComments(editor);
         var expression = editor.getTextInBufferRange(range);
         return [expression, range];
+    }
+
+    getCurrentParagraphIncludingComments(editor) {
+        var cursor = editor.getLastCursor();
+        var startRow = endRow = cursor.getBufferRow();
+
+        while (editor.lineTextForBufferRow(startRow)) {
+            startRow--;
+        }
+        while (editor.lineTextForBufferRow(endRow)) {
+            endRow++;
+        }
+
+        return {
+            start: { row: startRow + 1, column: 0 },
+            end: { row: endRow, column: 0 },
+        };
     }
 
     evalFlash(range) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -189,10 +189,11 @@ export default class REPL {
         var cursor = editor.getLastCursor();
         var startRow = endRow = cursor.getBufferRow();
 
-        while (editor.lineTextForBufferRow(startRow)) {
+        // lines must include non-whitespace characters
+        while (/\S/.test(editor.lineTextForBufferRow(startRow))) {
             startRow--;
         }
-        while (editor.lineTextForBufferRow(endRow)) {
+        while (/\S/.test(editor.lineTextForBufferRow(endRow))) {
             endRow++;
         }
 


### PR DESCRIPTION
This PR enables atom-tidalcycles to evaluate multiline expressions including comments.

### before
cannot evaluate expressions including comments...
![before](https://user-images.githubusercontent.com/1403842/27620514-26643528-5c05-11e7-9b84-9cbd484b42b0.gif)

### after
Evaluated successfully 😄 
![after](https://user-images.githubusercontent.com/1403842/27620511-2344a9b8-5c05-11e7-8ce4-bb322c35fcfd.gif)

The original source code of `getCurrentParagraphIncludingComments` is here:
https://discuss.atom.io/t/get-current-paragraph-buffer-range-is-not-returning-range-over-code-comments/24046