### PR TITLE
ADDS: open console panel only first time.

### DIFF
--- a/lib/console-view.js
+++ b/lib/console-view.js
@@ -7,6 +7,7 @@ class ConsoleView {
     }
 
     initUI() {
+        if (this.tidalConsole) return;
         this.tidalConsole = document.createElement('div');
         this.tidalConsole.classList.add('tidalcycles', 'console');
 


### PR DESCRIPTION
If (accidentally) booting Tidal more than once, for each time a new panel is added at the bottom of Atom. This patch avoids that.