### PR TITLE
add configurable boot file path

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -3,7 +3,7 @@
 var fs = require('fs');
 var spawn = require('child_process').spawn;
 var Range = require('atom').range;
-var bootFilePath = __dirname + "/BootTidal.hs"
+var defaultBootFilePath = __dirname + "/BootTidal.hs"
 var CONST_LINE = 'line'
 var CONST_MULTI_LINE = 'multi_line'
 
@@ -57,12 +57,17 @@ export default class REPL {
     }
 
     getGhciPath() {
-        var path = atom.config.get('tidalcycles.ghciPath');
-        return path;
+        return atom.config.get('tidalcycles.ghciPath');
+    }
+
+    getBootTidalPath() {
+        return atom.config.get('tidalcycles.bootTidalPath');
     }
 
     initTidal() {
-        var commands = fs.readFileSync(bootFilePath).toString().split('\n');
+        const configuredBootFilePath = this.getBootTidalPath();
+        const actualBootPath = configuredBootFilePath !== "" ? configuredBootFilePath : defaultBootFilePath;
+        var commands = fs.readFileSync(actualBootPath).toString().split('\n');
         for (var i = 0; i < commands.length; i++) {
             this.tidalSendLine(commands[i]);
         }

--- a/lib/tidalcycles.js
+++ b/lib/tidalcycles.js
@@ -10,6 +10,10 @@ export default {
         "ghciPath": {
             type: "string",
             default: "ghci"
+        },
+        "bootTidalPath": {
+            type: "string",
+            default: ""
         }
     },
 


### PR DESCRIPTION
Adds a new configuration setting so that the user can specify a path to their own unique Tidal boot file (instead of the embedded BootTidal.hs). 