### PR TITLE
Add runnow function

### DIFF
--- a/lib/BootTidal.hs
+++ b/lib/BootTidal.hs
@@ -29,4 +29,6 @@ let bps x = cps (x/2)
 let hush = mapM_ ($ silence) [d1,d2,d3,d4,d5,d6,d7,d8,d9,c1,c2,c3,c4,c5,c6,c7,c8,c9]
 let solo = (>>) hush
 
+let runnow d p = do { now <- getNow; d $ (pure (nextSam now)) ~> p }
+
 :set prompt "tidal> "


### PR DESCRIPTION
Adds the `runnow` function to the Tidal boot file. As described in [this post](http://lurk.org/groups/tidal/messages/topic/1zEAX0WkNyomiOdLAyuiMG) on lurk.org. Didn't manage to get `now` working as implemented in the emacs plugin, so this is a replacement which serves the same purpose.

Testable with:

```
runnow d1 $ seqP [
    (0, 12, sound "bd bd*2"),
    (4, 12, sound "hh*2 [sn cp] cp future*4"),
    (8, 12, sound (samples "arpy*8" (run 16)))
]
```