### PR TITLE
add option for current directory boot file

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,24 @@
+{
+  "js": {
+    "indent_size": 4,
+    "indent_char": " ",
+    "indent_level": 0,
+    "indent_with_tabs": false,
+    "preserve_newlines": true,
+    "max_preserve_newlines": 2,
+    "jslint_happy": true
+  },
+  "json": {
+    "indent_size": 4,
+    "indent_char": " ",
+    "indent_level": 0,
+    "indent_with_tabs": false,
+    "preserve_newlines": true,
+    "max_preserve_newlines": 2,
+    "jslint_happy": true
+  },
+  "less": {
+    "indent_char": " ",
+    "indent_size": 4
+  }
+}

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -3,7 +3,8 @@
 var fs = require('fs');
 var spawn = require('child_process').spawn;
 var Range = require('atom').range;
-var defaultBootFilePath = __dirname + "/BootTidal.hs"
+var defaultBootFileName = 'BootTidal.hs';
+var defaultBootFilePath = __dirname + '/' + defaultBootFileName;
 var CONST_LINE = 'line'
 var CONST_MULTI_LINE = 'multi_line'
 
@@ -16,7 +17,7 @@ export default class REPL {
         this.consoleView = consoleView;
 
         atom.commands.add('atom-workspace', {
-            "tidalcycles:boot": () => {
+            'tidalcycles:boot': () => {
                 if (this.editorIsTidal()) {
                     this.start();
                     return;
@@ -42,16 +43,18 @@ export default class REPL {
     }
 
     hush() {
-        this.tidalSendExpression("hush");
+        this.tidalSendExpression('hush');
     }
 
     doSpawn() {
-        this.repl = spawn(this.getGhciPath(), [], { shell: true });
+        this.repl = spawn(this.getGhciPath(), [], {
+            shell: true
+        });
         this.repl.stderr.on('data', (data) => {
-          console.error(data.toString('utf8'));
-          this.consoleView.logStderr();
-          this.consoleView.logStderr(data.toString('utf8'));
-          this.consoleView.logStderr();
+            console.error(data.toString('utf8'));
+            this.consoleView.logStderr();
+            this.consoleView.logStderr(data.toString('utf8'));
+            this.consoleView.logStderr();
         });
         this.repl.stdout.on('data', (data) => this.consoleView.logStdout(data.toString('utf8')));
     }
@@ -61,13 +64,23 @@ export default class REPL {
     }
 
     getBootTidalPath() {
-        return atom.config.get('tidalcycles.bootTidalPath');
+
+        const useCurrentDirectory = atom.config.get('tidalcycles.useBootFileInCurrentDirectory');
+        const rootDirectories = atom.project.rootDirectories;
+        const currentDirectoryPath = rootDirectories.length > 0 ?
+            rootDirectories[0].path + '/' + defaultBootFileName :
+            null;
+
+        if (fs.existsSync(currentDirectoryPath)) return currentDirectoryPath;
+
+        const configuredBootFilePath = atom.config.get('tidalcycles.bootTidalPath');
+        const actualBootPath = configuredBootFilePath !== '' ? configuredBootFilePath : defaultBootFilePath;
+        return actualBootPath;
     }
 
     initTidal() {
-        const configuredBootFilePath = this.getBootTidalPath();
-        const actualBootPath = configuredBootFilePath !== "" ? configuredBootFilePath : defaultBootFilePath;
-        var commands = fs.readFileSync(actualBootPath).toString().split('\n');
+        const bootPath = this.getBootTidalPath();
+        var commands = fs.readFileSync(bootPath).toString().split('\n');
         for (var i = 0; i < commands.length; i++) {
             this.tidalSendLine(commands[i]);
         }
@@ -204,8 +217,14 @@ export default class REPL {
             endRow++;
         }
         return {
-            start: { row: startRow + 1, column: 0 },
-            end: { row: endRow, column: 0 },
+            start: {
+                row: startRow + 1,
+                column: 0
+            },
+            end: {
+                row: endRow,
+                column: 0
+            },
         };
     }
 
@@ -218,16 +237,16 @@ export default class REPL {
         var decoration = editor.decorateMarker(
             marker, {
                 type: 'line',
-                class: "eval-flash"
+                class: 'eval-flash'
             });
 
         // return fn to flash error / success and destroy the flash
-        return function(cssClass) {
+        return function (cssClass) {
             decoration.setProperties({
                 type: 'line',
                 class: cssClass
             });
-            var destroy = function() {
+            var destroy = function () {
                 marker.destroy();
             };
             setTimeout(destroy, 120);

--- a/lib/tidalcycles.js
+++ b/lib/tidalcycles.js
@@ -7,13 +7,17 @@ export default {
     consoleView: null,
     tidalRepl: null,
     config: {
-        "ghciPath": {
-            type: "string",
-            default: "ghci"
+        'ghciPath': {
+            type: 'string',
+            default: 'ghci'
         },
-        "bootTidalPath": {
-            type: "string",
-            default: ""
+        'bootTidalPath': {
+            type: 'string',
+            default: ''
+        },
+        'useBootFileInCurrentDirectory': {
+            type: 'boolean',
+            default: false
         }
     },
 


### PR DESCRIPTION
Adds a new option to use a `BootTidal.hs` file in the current directory, if it exists. Boot preference order:

1. Current directory `BootTidal.hs`
2. Configured boot file path
3. Default `BootTidal.hs` file included with the package.

![current-directory-feature-sc](https://user-images.githubusercontent.com/9797/35656113-1671d8b2-06bb-11e8-94c1-74451f0c8d7d.png)

I also threw in an editor formatting config file (recommend the `atom-beautify` package). I also formatted the files I touched and normalized strings to use single quotes on those files.