### PR TITLE
Improves console view

### DIFF
--- a/lib/console-view.js
+++ b/lib/console-view.js
@@ -18,6 +18,18 @@ class ConsoleView {
         atom.workspace.addBottomPanel({
             item: this.tidalConsole
         });
+
+        atom.config.onDidChange( 'tidalcycles.onlyLogLastMessage', (data) =>{
+
+          if(data.newValue){
+              this.tidalConsole.classList.remove('scroll');
+          }else{
+            this.tidalConsole.classList.add('scroll');
+          }
+        });
+
+
+
     }
 
     serialize() {
@@ -33,17 +45,31 @@ class ConsoleView {
     }
 
     logStderr(text) {
-        this.logText(text, "error");
+        this.logText(text, true);
     }
-    logText(text,className) {
+
+    logText(text, error) {
         if (!text) return;
-        this.tidalConsole.scrollTop = this.tidalConsole.scrollHeight;
-        var textNode = document.createElement("span");
-        if(className){
-          textNode.className = className;
+        var pre = document.createElement("pre");
+        if (error) {
+            pre.className = "error";
         }
-        textNode.innerHTML = text.replace('\n', '<br/>');
-        this.log.appendChild(textNode);
+
+        if (atom.config.get('tidalcycles.onlyLogLastMessage')) {
+            this.log.innerHTML = "";
+        }
+        pre.innerHTML = text;
+        this.log.appendChild(pre);
+
+        if (!error && atom.config.get('tidalcycles.onlyShowWhenErrors')) {
+            this.tidalConsole.setAttribute('style', 'display:none');
+        } else {
+            this.tidalConsole.setAttribute('style', '');
+        }
+
+        this.tidalConsole.scrollTop = this.tidalConsole.scrollHeight;
+
+
     }
 }
 

--- a/lib/console-view.js
+++ b/lib/console-view.js
@@ -19,16 +19,14 @@ class ConsoleView {
             item: this.tidalConsole
         });
 
-        atom.config.onDidChange( 'tidalcycles.onlyLogLastMessage', (data) =>{
-
-          if(data.newValue){
-              this.tidalConsole.classList.remove('scroll');
-          }else{
-            this.tidalConsole.classList.add('scroll');
-          }
+        //sets the console max height
+        this.tidalConsole.setAttribute('style', 'max-height:'+
+          atom.config.get('tidalcycles.consoleMaxHeight')+'px;');
+        // listen for consoleMaxHeight changes
+        atom.config.onDidChange( 'tidalcycles.consoleMaxHeight', (data) =>{
+          this.tidalConsole.setAttribute('style', 'max-height:'+
+            data.newValue+'px;');
         });
-
-
 
     }
 
@@ -61,10 +59,10 @@ class ConsoleView {
         pre.innerHTML = text;
         this.log.appendChild(pre);
 
-        if (!error && atom.config.get('tidalcycles.onlyShowWhenErrors')) {
-            this.tidalConsole.setAttribute('style', 'display:none');
+        if (!error && atom.config.get('tidalcycles.onlyShowLogWhenErrors')) {
+            this.tidalConsole.classList.add('hidden');
         } else {
-            this.tidalConsole.setAttribute('style', '');
+            this.tidalConsole.classList.remove('hidden');
         }
 
         this.tidalConsole.scrollTop = this.tidalConsole.scrollHeight;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -12,9 +12,14 @@ export default class REPL {
 
     repl: null
     consoleView: null
+    stdErr: null
+    stdOut: null
+    stdTimer:0
 
     constructor(consoleView) {
         this.consoleView = consoleView;
+        this.stdErr = []
+        this.stdOut = []
 
         atom.commands.add('atom-workspace', {
             'tidalcycles:boot': () => {
@@ -51,12 +56,57 @@ export default class REPL {
             shell: true
         });
         this.repl.stderr.on('data', (data) => {
-            console.error(data.toString('utf8'));
-            this.consoleView.logStderr();
-            this.consoleView.logStderr(data.toString('utf8'));
-            this.consoleView.logStderr();
+          this.processStdErr(data);
         });
-        this.repl.stdout.on('data', (data) => this.consoleView.logStdout(data.toString('utf8')));
+        this.repl.stdout.on('data', (data) => {
+          this.processStdOut(data);
+        });
+    }
+
+    processStdOut(data){
+      this.stdOut.push(data.toString('utf8'))
+      this.processStd()
+    }
+
+    processStdErr(data){
+      this.stdErr.push(data.toString('utf8'))
+      this.processStd()
+    }
+
+    processStd(){
+      clearTimeout(this.stdTimer)
+      // defers the handler of stdOut/stdErr data
+      // by some arbitrary ammount of time (50ms)
+      // to get the buffer filled completly
+      this.stdTimer = setTimeout(()=>this.flushStd(),50);
+    }
+
+    flushStd(){
+
+      if(this.stdErr.length){
+        let t = this.stdErr.join('')
+        t = t.replace(/<interactive>.*error:/g,"")
+        t = t.replace(/ \(bound at.*/g,"")
+        this.consoleView.logStderr(t);
+        this.stdErr.length = 0
+        //dont care about stdOut if there are errors
+        this.stdOut.length = 0
+
+      }
+
+      if(this.stdOut.length){
+        let t = this.stdOut.join('')
+        t = t.replace(/tidal>.*Prelude>/g,"")
+        t = t.replace(/tidal>/g,"")
+        t = t.replace(/Prelude>/g,"")
+        t = t.replace(/Prelude.*\|/g,"")
+        t = t.replace(/GHCi.*help/g,"")
+        t = "t>"+t+"\n"
+        this.consoleView.logStdout(t);
+        this.stdOut.length = 0
+      }
+
+
     }
 
     getGhciPath() {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -85,8 +85,10 @@ export default class REPL {
 
       if(this.stdErr.length){
         let t = this.stdErr.join('')
-        t = t.replace(/<interactive>.*error:/g,"")
-        t = t.replace(/ \(bound at.*/g,"")
+        if(atom.config.get('tidalcycles.filterPromptFromLogMessages')){
+          t = t.replace(/<interactive>.*error:/g,"")
+          t = t.replace(/ \(bound at.*/g,"")
+        }
         this.consoleView.logStderr(t);
         this.stdErr.length = 0
         //dont care about stdOut if there are errors
@@ -96,12 +98,14 @@ export default class REPL {
 
       if(this.stdOut.length){
         let t = this.stdOut.join('')
-        t = t.replace(/tidal>.*Prelude>/g,"")
-        t = t.replace(/tidal>/g,"")
-        t = t.replace(/Prelude>/g,"")
-        t = t.replace(/Prelude.*\|/g,"")
-        t = t.replace(/GHCi.*help/g,"")
-        t = "t>"+t+"\n"
+        if(atom.config.get('tidalcycles.filterPromptFromLogMessages')){
+          t = t.replace(/tidal>.*Prelude>/g,"")
+          t = t.replace(/tidal>/g,"")
+          t = t.replace(/Prelude>/g,"")
+          t = t.replace(/Prelude.*\|/g,"")
+          t = t.replace(/GHCi.*help/g,"")
+          t = "t>"+t+"\n"
+        }
         this.consoleView.logStdout(t);
         this.stdOut.length = 0
       }

--- a/lib/tidalcycles.js
+++ b/lib/tidalcycles.js
@@ -20,7 +20,7 @@ export default {
             default: false,
             description: 'If a BootTidal.hs file is found at the root of your Atom project, it will be used to boot Tidal.'
         },
-        'onlyShowWhenErrors': {
+        'onlyShowLogWhenErrors': {
             type: 'boolean',
             default: false,
             description: 'Only show console if last message was an error.'
@@ -29,6 +29,16 @@ export default {
             type: 'boolean',
             default: false,
             description: 'Only log last message to the console.'
+        },
+        'filterPromptFromLogMessages': {
+            type: 'boolean',
+            default: true,
+            description: 'Whether to filter out those long prompt comming from ghci.'
+        },
+        'consoleMaxHeight': {
+            type: 'integer',
+            default: 100,
+            description: 'The console maximum height in pixels.'
         }
     },
 

--- a/lib/tidalcycles.js
+++ b/lib/tidalcycles.js
@@ -19,22 +19,32 @@ export default {
             type: 'boolean',
             default: false,
             description: 'If a BootTidal.hs file is found at the root of your Atom project, it will be used to boot Tidal.'
+        },
+        'onlyShowWhenErrors': {
+            type: 'boolean',
+            default: false,
+            description: 'Only show console if last message was an error.'
+        },
+        'onlyLogLastMessage': {
+            type: 'boolean',
+            default: false,
+            description: 'Only log last message to the console.'
         }
     },
 
     activate(state) {
-        consoleView = new ConsoleView(state.consoleViewState);
-        tidalRepl = new Repl(consoleView);
+        this.consoleView = new ConsoleView(state.consoleViewState);
+        this.tidalRepl = new Repl(this.consoleView);
     },
 
     deactivate() {
-        consoleView.destroy();
-        tidalRepl.destroy();
+        this.consoleView.destroy();
+        this.tidalRepl.destroy();
     },
 
     serialize() {
         return {
-            consoleViewState: consoleView.serialize()
+            consoleViewState: this.consoleView.serialize()
         };
     }
 

--- a/styles/tidal.less
+++ b/styles/tidal.less
@@ -43,13 +43,11 @@ atom-text-editor.editor .line {
 }
 
 atom-panel div.tidalcycles.console {
-  padding: 3px 10px;
-  &.scroll{
-    height: 100px;
-    padding: 3px 10px;
-    overflow: scroll;
-
+  &.hidden{
+    display: none;
   }
+  padding: 3px 10px;
+  overflow: scroll;
   pre {
     font-family: Consolas, monospace;
     font-size: 14px;

--- a/styles/tidal.less
+++ b/styles/tidal.less
@@ -43,12 +43,17 @@ atom-text-editor.editor .line {
 }
 
 atom-panel div.tidalcycles.console {
-  height: 100px;
   padding: 3px 10px;
-  font-size: 14px;
-  overflow: scroll;
-  font-family: Consolas, monospace;
+  &.scroll{
+    height: 100px;
+    padding: 3px 10px;
+    overflow: scroll;
 
+  }
+  pre {
+    font-family: Consolas, monospace;
+    font-size: 14px;
+  }
   .error{
     color: @text-color-error;
   }


### PR DESCRIPTION
This PR introduces some configurable options to get a better experience with the console view

- `onlyShowLogWhenErrors`
  Only show console if last message was an error.
- `onlyLogLastMessage`
  Only log last message to the console. Removes any previous log
- `filterPromptFromLogMessages`
  Whether to filter out those long prompt comming from ghci.
- `consoleMaxHeight`
  The console maximum height in pixels. Now console view has no fixed height but rather a configurable maximum height