### PR TITLE
fix: add non macOS keymaps

### DIFF
--- a/keymaps/tidal.json
+++ b/keymaps/tidal.json
@@ -5,6 +5,8 @@
         "cmd-enter": "tidalcycles:eval-multi-line",
         "ctrl-enter": "tidalcycles:eval-multi-line",
         "alt-cmd-enter": "tidalcycles:eval-multi-line-copy",
-        "shift-cmd-h": "tidalcycles:hush"
+        "alt-ctrl-enter": "tidalcycles:eval-multi-line-copy",
+        "shift-cmd-h": "tidalcycles:hush",
+        "shift-ctrl-h": "tidalcycles:hush"
     }
 }


### PR DESCRIPTION
Although it is possible to use the <kbd>super</kbd> key to mimic <kbd>cmd</kbd>, I think it's more intuitive for non macOS systems to use <kbd>ctrl</kbd>.