### PR TITLE
Make initTidal understand code blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 npm-debug.log
 node_modules
 *.tidal
+.idea

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -134,10 +134,18 @@ export default class REPL {
 
     initTidal() {
         const bootPath = this.getBootTidalPath();
-        var commands = fs.readFileSync(bootPath).toString().split('\n');
-        for (var i = 0; i < commands.length; i++) {
-            this.tidalSendLine(commands[i]);
-        }
+        const blocks = fs.readFileSync(bootPath)
+            .toString()
+            .split('\n\n')
+            .map(block => block.replace(":{", "").replace(":}", ""));
+
+        blocks.forEach(block => {
+            if (block.startsWith(":")) {
+                block.split("\n").forEach(row => this.tidalSendLine(row))
+            } else {
+                this.tidalSendExpression(block);
+            }
+        });
     }
 
     stdinWrite(command) {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -140,7 +140,7 @@ export default class REPL {
             .map(block => block.replace(":{", "").replace(":}", ""));
 
         blocks.forEach(block => {
-            if (block.startsWith(":")) {
+            if (block.startsWith(":set")) {
                 block.split("\n").forEach(row => this.tidalSendLine(row))
             } else {
                 this.tidalSendExpression(block);

--- a/spec/repl-spec.js
+++ b/spec/repl-spec.js
@@ -1,0 +1,31 @@
+const REPL = require('../lib/repl.js')
+
+describe('repl', () => {
+  it('should load code blocks on boot', () => {
+    let repl = new REPL()
+    spyOn(repl, 'getBootTidalPath').andReturn("lib/BootTidal.hs")
+    spyOn(repl, 'tidalSendLine')
+    spyOn(repl, 'tidalSendExpression')
+
+    repl.initTidal()
+
+    expect(repl.tidalSendLine.callCount).toBe(5)
+    expect(repl.tidalSendExpression.callCount).toBe(4)
+    expect(repl.tidalSendLine.calls[0].args[0]).toBe(':set -XOverloadedStrings')
+    expect(repl.tidalSendExpression.calls[1].args[0]).toBe('-- total latency = oLatency + cFrameTimespan\ntidal <- startTidal (superdirtTarget {oLatency = 0.1, oAddress = "127.0.0.1", oPort = 57120}) (defaultConfig {cFrameTimespan = 1/20})')
+  })
+
+  it('should send :set lines as single lines on boot', () => {
+    let repl = new REPL()
+    spyOn(repl, 'getBootTidalPath').andReturn("lib/BootTidal.hs")
+    spyOn(repl, 'tidalSendLine')
+    spyOn(repl, 'tidalSendExpression')
+
+    repl.initTidal()
+
+    expect(repl.tidalSendLine.calls[0].args[0]).toBe(':set -XOverloadedStrings')
+    expect(repl.tidalSendLine.calls[1].args[0]).toBe(':set prompt ""')
+    expect(repl.tidalSendLine.calls[2].args[0]).toBe(':set prompt-cont ""')
+    expect(repl.tidalSendLine.calls[3].args[0]).toBe(':set prompt "tidal> "')
+  })
+})


### PR DESCRIPTION
Fix #29 . With this is possible to define code blocks in BootTidal.hs without using `:{` and `:}`.
Code tested by hand. I'm trying to understand how to do it with unit tests.