### PR TITLE
Handle 'stack exec' style ghci path

### DIFF
--- a/lib/ghc.js
+++ b/lib/ghc.js
@@ -28,8 +28,8 @@ export default class Ghc {
   static commandPath(name) {
     let propertyValue = Ghc.ghciPathProperty()
     if (propertyValue) {
-      return path.basename(propertyValue) === 'ghci'
-        ? path.join(path.parse(propertyValue).dir, name)
+      return propertyValue.endsWith('ghci')
+        ? propertyValue.substring(0, propertyValue.length - 4) + name
         : path.join(propertyValue, name)
     } else {
       return name

--- a/spec/ghci-spec.js
+++ b/spec/ghci-spec.js
@@ -33,6 +33,13 @@ describe('ghc', () => {
       expect(Ghc.commandPath('ghci')).toBe('/some/path/ghci')
       expect(Ghc.commandPath('ghc-pkg')).toBe('/some/path/ghc-pkg')
     })
+
+    it(`should handle stack exec path style`, () => {
+      atom.config.set('tidalcycles.ghciPath', 'stack exec --package tidal – ghci')
+
+      expect(Ghc.commandPath('ghci')).toBe('stack exec --package tidal – ghci')
+      expect(Ghc.commandPath('ghc-pkg')).toBe('stack exec --package tidal – ghc-pkg')
+    })
   })
 
   describe('tidal data dir', () => {


### PR DESCRIPTION
An user writed me that:
> My ghci path :  stack exec --package tidal – ghci not working any more?

So I make it working, though it's not a valid path in my opinion