### PR TITLE
Add osc receiver for remote evaluation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ The atom plugin is listening on this specified port for incoming osc messages.
 
 * Default Port: 3333
 
+### Osc Eval Ip
+The atom plugin ist listenting on this ip address for incoming osc messages.
+
+* Default Ip: 127.0.0.1
+
 ### Osc Eval Address
 The atom plugin is filtering incoming osc messages with this specified address. 
 * Default address: /atom/eval

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ etc...
 * *%ts*: current timestamp (unix format, seconds)
 * *%diff*: character comparison difference between last two evaluations
 
+### Osc Eval Port
+The atom plugin is listening on this specified port for incoming osc messages.
+
+* Default Port: 3333
+
+### Osc Eval Address
+The atom plugin is filtering incoming osc messages with this specified address. 
+* Default address: /atom/eval
+
+Three values are considered:
+1. line
+2. multi_line
+3. whole_editor
+
 ### Other configurations
   * **Show error notifications**: show atom notifications on error  
   * **Only Log Last Message**: shows only last log message on console

--- a/lib/osc-loader.js
+++ b/lib/osc-loader.js
@@ -1,0 +1,93 @@
+'use babel'
+
+import * as path from 'path';
+import { spawn } from 'child_process';
+import { EventEmitter } from 'events';
+
+const oscPortProperty = 'tidalcycles.oscEvalPort';
+const oscAddressProperty = 'tidalcycles.oscEvalAddress';
+
+export default class OscLoader extends EventEmitter {
+
+    constructor(tidalRepl) {
+        super();
+        console.log("listening on port", atom.config.get(oscPortProperty));
+        this.port = atom.config.get(oscPortProperty);
+        this.server = spawn(
+            'node',
+            [path.resolve(__dirname, 'osc-server.js'), this.port.toString()],
+            {
+                cwd: path.resolve(__dirname, '..'),
+            },
+        );
+        this.server.stdout.on('data', this.stdout);
+        this.server.stderr.on('data', this.stderr);
+        this.server.on('exit', this.exit);
+
+        this.on(atom.config.get(oscAddressProperty), (args) => {tidalRepl.eval(args[0], false);});
+    }
+
+
+    setPort(port) {
+      try {
+          this.server.kill()
+
+      } catch (e) {
+          console.error(e)
+      }
+
+      this.port = port
+      console.log("setting port to " + port)
+      this.server = spawn(
+          'node',
+          [path.resolve(__dirname, 'osc-server.js'), this.port.toString()],
+          {
+              cwd: path.resolve(__dirname, '..'),
+          },
+      )
+      this.server.stdout.on('data', this.stdout)
+      this.server.stderr.on('data', this.stderr)
+      this.server.on('exit', this.exit)
+    }
+
+    destroy() {
+        try {
+            this.server.kill()
+        } catch (e) {
+            console.error(e)
+        }
+    }
+
+    // for live coding, when new event listener is added, remove
+    // previous listeners at the same address
+    on(addr, callback){
+      this.removeAllListeners(addr)
+      super.on(addr, callback)
+    }
+
+    stdout = (output) => {
+
+        const s = output.toString().trim()
+
+        s.split('\n').forEach(line => {
+            let msg;
+            try {
+                msg = JSON.parse(line);
+            } catch (e) { console.log("error", e)}
+
+            if (msg) {
+                this.emit('*', msg)
+                this.emit(msg.address, msg.args)
+            }
+        });
+    };
+
+
+    stderr = (output) => {
+        console.error(output.toString())
+    };
+
+    exit = (code) => {
+        console.log('[TidalCycles] OSC server exited with code', code)
+    };
+}

--- a/lib/osc-loader.js
+++ b/lib/osc-loader.js
@@ -1,93 +1,42 @@
 'use babel'
 
-import * as path from 'path';
-import { spawn } from 'child_process';
 import { EventEmitter } from 'events';
+const osc = require('osc-min');
 
-const oscPortProperty = 'tidalcycles.oscEvalPort';
+import OscServer from "./osc-server";
+
 const oscAddressProperty = 'tidalcycles.oscEvalAddress';
 
 export default class OscLoader extends EventEmitter {
 
-    constructor(tidalRepl) {
-        super();
-        console.log("listening on port", atom.config.get(oscPortProperty));
-        this.port = atom.config.get(oscPortProperty);
-        this.server = spawn(
-            'node',
-            [path.resolve(__dirname, 'osc-server.js'), this.port.toString()],
-            {
-                cwd: path.resolve(__dirname, '..'),
-            },
-        );
-        this.server.stdout.on('data', this.stdout);
-        this.server.stderr.on('data', this.stderr);
-        this.server.on('exit', this.exit);
+    consoleView = null;
+    tidalRepl = null;
 
-        this.on(atom.config.get(oscAddressProperty), (args) => {tidalRepl.eval(args[0], false);});
+    constructor(consoleView, tidalRepl) {
+        super();
+        this.address = atom.config.get(oscAddressProperty);
+        this.consoleView = consoleView;
+        this.tidalRepl = tidalRepl;
     }
 
+    init() {
+        this.server = new OscServer(this.consoleView);
+        this.server.start();
 
-    setPort(port) {
-      try {
-          this.server.kill()
+        this.server.sock.on('message', (msg) => {
+            let resultMap = osc.fromBuffer(msg);
 
-      } catch (e) {
-          console.error(e)
-      }
-
-      this.port = port
-      console.log("setting port to " + port)
-      this.server = spawn(
-          'node',
-          [path.resolve(__dirname, 'osc-server.js'), this.port.toString()],
-          {
-              cwd: path.resolve(__dirname, '..'),
-          },
-      )
-      this.server.stdout.on('data', this.stdout)
-      this.server.stderr.on('data', this.stderr)
-      this.server.on('exit', this.exit)
+            if (resultMap.address === this.address) {
+                this.tidalRepl.eval(resultMap.args[0].value, false);
+            }
+        });
     }
 
     destroy() {
         try {
-            this.server.kill()
+            this.server.destroy();
         } catch (e) {
-            console.error(e)
+            this.consoleView.logStderr(`OSC server has problems while destroying: \n${e}`);
         }
     }
-
-    // for live coding, when new event listener is added, remove
-    // previous listeners at the same address
-    on(addr, callback){
-      this.removeAllListeners(addr)
-      super.on(addr, callback)
-    }
-
-    stdout = (output) => {
-
-        const s = output.toString().trim()
-
-        s.split('\n').forEach(line => {
-            let msg;
-            try {
-                msg = JSON.parse(line);
-            } catch (e) { console.log("error", e)}
-
-            if (msg) {
-                this.emit('*', msg)
-                this.emit(msg.address, msg.args)
-            }
-        });
-    };
-
-
-    stderr = (output) => {
-        console.error(output.toString())
-    };
-
-    exit = (code) => {
-        console.log('[TidalCycles] OSC server exited with code', code)
-    };
 }

--- a/lib/osc-server.js
+++ b/lib/osc-server.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+function printMessage(msg) {
+    if (msg.oscType === 'bundle') {
+        msg.elements.forEach(printMessage);
+    }
+    else {
+        msg.args = msg.args.map((a) => a.value);
+        console.log(JSON.stringify(msg));
+    }
+}
+{
+    const PORT = process.argv[2] || 57121;
+
+    const dgram = require('dgram');
+    const osc = require('osc-min');
+    const sock = dgram.createSocket('udp4', (buf) => {
+        try {
+          printMessage(osc.fromBuffer(buf));
+        } catch (e) {
+          console.log("ERROR", e)
+        }
+    });
+  //  console.log("opening socket server on port ", PORT)
+    sock.bind(PORT);
+}

--- a/lib/osc-server.js
+++ b/lib/osc-server.js
@@ -1,25 +1,43 @@
-#!/usr/bin/env node
-function printMessage(msg) {
-    if (msg.oscType === 'bundle') {
-        msg.elements.forEach(printMessage);
-    }
-    else {
-        msg.args = msg.args.map((a) => a.value);
-        console.log(JSON.stringify(msg));
-    }
-}
-{
-    const PORT = process.argv[2] || 57121;
+'use babel'
 
-    const dgram = require('dgram');
-    const osc = require('osc-min');
-    const sock = dgram.createSocket('udp4', (buf) => {
-        try {
-          printMessage(osc.fromBuffer(buf));
-        } catch (e) {
-          console.log("ERROR", e)
+const dgram = require('dgram');
+const oscPortProperty = 'tidalcycles.oscEvalPort';
+const oscIpProperty = 'tidalcycles.oscEvalIp';
+
+export default class OscServer {
+
+    port = null;
+    ip = null;
+    sock = null;
+    consoleView = null;
+
+    constructor(consoleView) {
+        this.port =  atom.config.get(oscPortProperty);
+        this.ip =  atom.config.get(oscIpProperty);
+        this.consoleView = consoleView;
+        this.sock = dgram.createSocket('udp4');
+    }
+
+    start() {
+        this.sock.on('error', (err) => {
+           this.consoleView.logStderr(`OSC server error: \n${err.stack}`)
+           this.sock.close();
+        });
+
+        this.sock.on('listening', () => {
+            this.consoleView.logStdout(`Listening for external osc messages on ${this.ip}:${this.port}`)
+        });
+
+        this.sock.bind(this.port, this.ip);
+    }
+
+    stop() {
+        if (this.sock) {
+            this.sock.close();
         }
-    });
-  //  console.log("opening socket server on port ", PORT)
-    sock.bind(PORT);
+    }
+
+    destroy() {
+        this.stop();
+    }
 }

--- a/lib/tidalcycles.js
+++ b/lib/tidalcycles.js
@@ -57,18 +57,6 @@ export default {
         description: 'Show atom notifications on error.',
         order: 55
       },
-      'oscEvalPort': {
-        type: 'integer',
-        default: 3333,
-        description: `OSC port for receiving eval messages.`,
-        order: 56
-      },
-      'oscEvalAddress': {
-          type: 'string',
-          default: '/atom/eval',
-          description: `OSC address for receiving eval messages. Expected arguments are 'line', 'multi_line' and 'whole_editor'.`,
-          order: 57
-      },
       'onlyShowLogWhenErrors': {
         type: 'boolean',
         default: false,
@@ -80,6 +68,24 @@ export default {
         default: false,
         description: 'Only log last message to the console.',
         order: 70
+      },
+      'oscEvalPort': {
+        type: 'integer',
+        default: 3333,
+        description: `OSC port for receiving eval messages.`,
+        order: 80
+      },
+      'oscEvalIp': {
+        type: 'string',
+        default: '127.0.0.1',
+        description: `OSC ip address for receiving eval messages.`,
+        order: 81
+      },
+      'oscEvalAddress': {
+        type: 'string',
+        default: '/atom/eval',
+        description: `OSC address for receiving eval messages. Expected arguments are 'line', 'multi_line' and 'whole_editor'.`,
+        order: 82
       }
     },
 
@@ -90,12 +96,14 @@ export default {
       this.ghc.init();
       this.bootTidal = new BootTidal(this.ghc, atom.project.rootDirectories);
       this.tidalRepl = new Repl(this.consoleView, this.ghc, this.bootTidal);
-      this.oscLoader = new OscLoader(this.tidalRepl);
+      this.oscLoader = new OscLoader(this.consoleView, this.tidalRepl);
+      this.oscLoader.init();
     },
 
     deactivate() {
         this.consoleView.destroy();
         this.tidalRepl.destroy();
+        this.oscLoader.destroy();
     },
 
     serialize() {

--- a/lib/tidalcycles.js
+++ b/lib/tidalcycles.js
@@ -2,6 +2,7 @@
 
 import ConsoleView from './console-view';
 import Repl from './repl';
+import OscLoader from './osc-loader';
 import AutocompleteProvider from './autocomplete-provider';
 import Ghc from './ghc';
 import BootTidal from './boot-tidal';
@@ -49,11 +50,24 @@ export default {
         description: `Console prompt. Look at the docs for available placeholders`,
         order: 50
       },
+
       'showErrorNotifications': {
         type: 'boolean',
         default: true,
         description: 'Show atom notifications on error.',
         order: 55
+      },
+      'oscEvalPort': {
+        type: 'integer',
+        default: 3333,
+        description: `OSC port for receiving eval messages.`,
+        order: 56
+      },
+      'oscEvalAddress': {
+          type: 'string',
+          default: '/atom/eval',
+          description: `OSC address for receiving eval messages. Expected arguments are 'line', 'multi_line' and 'whole_editor'.`,
+          order: 57
       },
       'onlyShowLogWhenErrors': {
         type: 'boolean',
@@ -76,6 +90,7 @@ export default {
       this.ghc.init();
       this.bootTidal = new BootTidal(this.ghc, atom.project.rootDirectories);
       this.tidalRepl = new Repl(this.consoleView, this.ghc, this.bootTidal);
+      this.oscLoader = new OscLoader(this.tidalRepl);
     },
 
     deactivate() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,11 @@
         "space-pen": "^5.1.2"
       }
     },
+    "binpack": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/binpack/-/binpack-0.1.0.tgz",
+      "integrity": "sha1-vT0JdMPyoERuF99PYLVacqIFqX4="
+    },
     "d": {
       "version": "0.1.1",
       "resolved": "http://registry.npmjs.org/d/-/d-0.1.1.tgz",
@@ -20,6 +25,11 @@
       "requires": {
         "es5-ext": "~0.10.2"
       }
+    },
+    "dgram": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dgram/-/dgram-1.0.1.tgz",
+      "integrity": "sha1-N/OyAPgDOl/3WTAwicgc42G2UcM="
     },
     "emissary": {
       "version": "1.3.3",
@@ -128,6 +138,14 @@
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "osc-min": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/osc-min/-/osc-min-1.1.2.tgz",
+      "integrity": "sha512-8DbiO8ME85R75stgNVCZtHxB9MNBBNcyy+isNBXrsFeinXGjwNAauvKVmGlfRas5VJWC/mhzIx7spR2gFvWxvg==",
+      "requires": {
+        "binpack": "~0"
+      }
     },
     "property-accessors": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     ]
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.0.3"
+    "atom-space-pen-views": "^2.0.3",
+    "osc-min": "^1.1.1",
+    "dgram": "^1.0.1"
   },
   "repository": "https://github.com/tidalcycles/atom-tidalcycles",
   "license": "GPL-3.0",


### PR DESCRIPTION
I extend the atom plugin by an osc receiver. With the osc receiver you are able to evaluate the editor code based on the mouse cursor position.

## Configuration

### Osc Eval Port
The atom plugin is listening on this specified port for incoming osc messages.

* Default Port: 3333

### Osc Eval Address
The atom plugin is filtering incoming osc messages with this specified address. 
* Default address: /atom/eval

Three values are considered:
1. line
2. multi_line
3. whole_editor
