### PR TITLE
Rename the variable arguments in osc-loader

### DIFF
--- a/lib/osc-loader.js
+++ b/lib/osc-loader.js
@@ -24,21 +24,21 @@ export default class OscLoader extends EventEmitter {
             let resultMap = osc.fromBuffer(msg);
 
             if (resultMap.address === this.address) {
-                let arguments = this.asDictionary(resultMap.args)
+                const resultDict = this.asDictionary(resultMap.args)
 
-                if (arguments['row'] && arguments['column']) {
-                    this.editor.goTo(arguments['row'] - 1, arguments['column'])
+                if (resultDict['row'] && resultDict['column']) {
+                    this.editor.goTo(resultDict['row'] - 1, resultDict['column'])
                 }
 
-                this.tidalRepl.eval(arguments['type'], false);
+                this.tidalRepl.eval(resultDict['type'], false);
             }
         });
     }
 
-    asDictionary (arguments) {
+    asDictionary (oscMap) {
         let dictionary = {}
-        for (var i = 0; i < arguments.length; i+=2) {
-            dictionary[arguments[i].value] = arguments[i+1].value
+        for (var i = 0; i < oscMap.length; i+=2) {
+            dictionary[oscMap[i].value] = oscMap[i+1].value
         }
         return dictionary
     }


### PR DESCRIPTION
I tried to run OSC evaluation in the current plugin version (3.16.6.). However, this is currently not possible. 
This is because the javascript keyword "arguments" was used. I renamed every occurence of arguments and tried to rename it more semantically.

Further informations: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments