### PR TITLE
Fix syntax highlighting for d1,d2...d10,d11...

### DIFF
--- a/grammars/tidal.cson
+++ b/grammars/tidal.cson
@@ -15,8 +15,8 @@
     'name': 'keyword.operator.function.infix.haskell'
   }
   {
-    'match': '\\b(d[1-9])\\b'
-    'name': 'support.function.tidalcycles'
+    'match': '\\b(d[1-9][0-9]?)\\b'
+    'name': 'keyword.control.haskell'
   }
   {
     'match': '\\(\\)'


### PR DESCRIPTION
Fix #154 