### PR TITLE
Tidal listener

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -5,9 +5,10 @@ export default {
     type: 'string',
     default: 'default',
     enum: [
-      { value: 'default', description: 'Default (ghc installed through cabal)'},
-      { value: 'stack', description: 'Stack'},
-      { value: 'nix', description: 'Nix'}
+      { value: 'default', description: 'Default (ghc installed through cabal)' },
+      { value: 'stack', description: 'Stack' },
+      { value: 'nix', description: 'Nix' },
+      { value: 'listener', description: 'tidal-listener' }
     ],
     order: 0
   },

--- a/lib/tidal-listener-repl.js
+++ b/lib/tidal-listener-repl.js
@@ -24,7 +24,6 @@ export default class Repl {
   start() {
     this.status.reset()
 
-    // this.listener = child_process.spawn('tidal-listener', [], { shell: true });
     this.listener = child_process.spawn('tidal-listener', []);
     this.listener.stderr.on('data', data => {
       this.consoleView.logStderr(data)

--- a/lib/tidal-listener-repl.js
+++ b/lib/tidal-listener-repl.js
@@ -37,21 +37,27 @@ export default class Repl {
       let resultMap = osc.fromBuffer(msg);
 
       switch (resultMap.address) {
+        case '/code/ok':
+          this.consoleView.logPromptOut('')
+          break;
         case '/code/error':
           let id = resultMap.args[0].value;
           let message = resultMap.args[1].value;
           this.consoleView.logPromptErr(`Error in evaluation: ${message}`);
-          console.log(resultMap);
+          break;
+        case '/code/highlight':
+          // TODO: handle code highlight
           break;
         case '/dirt/handshake':
           this.consoleView.logPromptErr(`Waiting for SuperDirt`);
-          console.log(resultMap)
           break;
         default:
           this.consoleView.logPromptOut(`Received an unknown message: ${resultMap.address}`)
-          console.warn(resultMap)
       }
     });
+
+    // TODO: remove this log
+    // console.log(resultMap);
 
     this.udp.on('error', (err) => {
        this.consoleView.logPromptErr(`tidal-listener error: \n${err.stack}`)

--- a/lib/tidal-listener-repl.js
+++ b/lib/tidal-listener-repl.js
@@ -12,6 +12,8 @@ export default class Repl {
     this.consoleView = consoleView;
     this.status = status
     this.editor = editor
+    this.stdOut = []
+    this.stdErr = []
 
     this.mutes = [...Array(16).keys()]
       .reduce((acc, cur) => {
@@ -25,10 +27,24 @@ export default class Repl {
 
     this.listener = child_process.spawn('tidal-listener', []);
     this.listener.stderr.on('data', data => {
-      this.consoleView.logStderr(data)
+      this.stdErr.push(data.toString('utf8'))
+      setTimeout(() => {
+        if (this.stdErr.length) {
+          let err = this.stdErr.join('')
+          this.stdErr.length = 0;
+          this.consoleView.logStderr(err)
+        }
+      }, 50)
     });
     this.listener.stdout.on('data', data => {
-      this.consoleView.logStdout(data)
+      this.stdOut.push(data.toString('utf8'))
+      setTimeout(() => {
+        if (this.stdOut.length) {
+          let log = this.stdOut.join('')
+          this.stdOut.length = 0
+          this.consoleView.logStdlog(log)
+        }
+      }, 50)
     });
 
     this.udp = dgram.createSocket('udp4');
@@ -43,7 +59,7 @@ export default class Repl {
         case '/code/error':
           let id = resultMap.args[0].value;
           let message = resultMap.args[1].value;
-          this.consoleView.logPromptErr(`Error in evaluation: ${message}`);
+          this.consoleView.logPromptErr(message);
           break;
         case '/code/highlight':
           // TODO: handle code highlight
@@ -55,9 +71,6 @@ export default class Repl {
           this.consoleView.logPromptOut(`Received an unknown message: ${resultMap.address}`)
       }
     });
-
-    // TODO: remove this log
-    // console.log(resultMap);
 
     this.udp.on('error', (err) => {
        this.consoleView.logPromptErr(`tidal-listener error: \n${err.stack}`)

--- a/lib/tidal-listener-repl.js
+++ b/lib/tidal-listener-repl.js
@@ -1,0 +1,137 @@
+'use babel';
+
+const dgram = require('dgram');
+const osc = require('osc-min');
+const child_process = require('child_process');
+
+export default class Repl {
+
+  consoleView = null
+
+  constructor(consoleView, bootTidal, status, editor) {
+    this.consoleView = consoleView;
+    this.bootTidal = bootTidal
+    this.status = status
+    this.editor = editor
+
+    this.mutes = [...Array(16).keys()]
+      .reduce((acc, cur) => {
+        acc[`${cur+1}`] = false
+        return acc;
+      }, {});
+  }
+
+  start() {
+    this.status.reset()
+
+    // this.listener = child_process.spawn('tidal-listener', [], { shell: true });
+    this.listener = child_process.spawn('tidal-listener', []);
+    this.listener.stderr.on('data', data => {
+      this.consoleView.logStderr(data)
+    });
+    this.listener.stdout.on('data', data => {
+      this.consoleView.logStdout(data)
+    });
+
+    this.udp = dgram.createSocket('udp4');
+
+    this.udp.on('message', (msg) => {
+      let resultMap = osc.fromBuffer(msg);
+
+      switch (resultMap.address) {
+        case '/code/error':
+          let id = resultMap.args[0].value;
+          let message = resultMap.args[1].value;
+          this.consoleView.logStderr(`Error in evaluation: ${message}`);
+          console.log(resultMap);
+          break;
+        case '/dirt/handshake':
+          this.consoleView.logStderr(`Waiting for SuperDirt`);
+          console.log(resultMap)
+          break;
+        default:
+          this.consoleView.logStdout(`Received an unknown message: ${resultMap.address}`)
+          console.warn(resultMap)
+      }
+    });
+
+    this.udp.on('error', (err) => {
+       this.consoleView.logStderr(`tidal-listener error: \n${err.stack}`)
+       this.udp.close();
+    });
+
+    this.udp.on('listening', () => {
+        this.consoleView.logStdout(`Listening for tidal-listener responses `)
+    });
+
+    this.udp.bind(6012, this.ip);
+  }
+
+  hush() {
+    this.tidalSendExpression('hush');
+  }
+
+  tidalSendExpression(expression) {
+    var buf = osc.toBuffer({
+      address: "/code",
+      args: ["ident", expression] // TODO: ident should be an id
+    });
+
+    this.udp.send(buf, 0, buf.length, 6011, "localhost");
+
+  }
+
+  eval(evalType, copy) {
+    if (!this.editor.isTidal()) return;
+
+    if (!this.listener || this.listener.killed) this.start();
+    this.editor.currentEvaluations(evalType)
+      .filter(eval => eval.expression && eval.range)
+      .forEach(eval => {
+        this.status.eval({ characters: eval.expression.length })
+
+        var unflash = this.editor.evalFlash(eval.range);
+        if (copy) {
+          this.editor.copyRange(eval.range);
+        }
+
+        this.tidalSendExpression(eval.expression);
+
+        if (unflash) {
+          unflash('eval-success');
+        }
+      })
+  }
+
+  toggleMute(connection) {
+    let command = this.mutes[connection]
+      ? `unmute ${connection}`
+      : `mute ${connection}`
+
+    this.tidalSendExpression(command)
+
+    this.mutes[connection] = !this.mutes[connection]
+    this.consoleView.logMutes(this.mutes, command)
+  }
+
+  unmuteAll() {
+    let command = 'unmuteAll'
+
+    this.tidalSendExpression(command)
+
+    for (key of Object.keys(this.mutes)) {
+      this.mutes[key] = false
+    }
+    this.consoleView.logMutes(this.mutes, command)
+  }
+
+  destroy() {
+    if (this.listener) {
+      this.listener.kill();
+    }
+    if (this.udp) {
+      this.udp.close();
+    }
+  }
+
+}

--- a/lib/tidal-listener-repl.js
+++ b/lib/tidal-listener-repl.js
@@ -8,9 +8,8 @@ export default class Repl {
 
   consoleView = null
 
-  constructor(consoleView, bootTidal, status, editor) {
+  constructor(consoleView, status, editor) {
     this.consoleView = consoleView;
-    this.bootTidal = bootTidal
     this.status = status
     this.editor = editor
 
@@ -41,26 +40,26 @@ export default class Repl {
         case '/code/error':
           let id = resultMap.args[0].value;
           let message = resultMap.args[1].value;
-          this.consoleView.logStderr(`Error in evaluation: ${message}`);
+          this.consoleView.logPromptErr(`Error in evaluation: ${message}`);
           console.log(resultMap);
           break;
         case '/dirt/handshake':
-          this.consoleView.logStderr(`Waiting for SuperDirt`);
+          this.consoleView.logPromptErr(`Waiting for SuperDirt`);
           console.log(resultMap)
           break;
         default:
-          this.consoleView.logStdout(`Received an unknown message: ${resultMap.address}`)
+          this.consoleView.logPromptOut(`Received an unknown message: ${resultMap.address}`)
           console.warn(resultMap)
       }
     });
 
     this.udp.on('error', (err) => {
-       this.consoleView.logStderr(`tidal-listener error: \n${err.stack}`)
+       this.consoleView.logPromptErr(`tidal-listener error: \n${err.stack}`)
        this.udp.close();
     });
 
     this.udp.on('listening', () => {
-        this.consoleView.logStdout(`Listening for tidal-listener responses `)
+        this.consoleView.logPromptOut(`Listening for tidal-listener responses `)
     });
 
     this.udp.bind(6012, this.ip);

--- a/lib/tidalcycles.js
+++ b/lib/tidalcycles.js
@@ -24,7 +24,7 @@ export default {
       this.consoleView.initUI();
 
       if (atom.config.get('tidalcycles.interpreter') === 'listener') {
-        this.repl = new TidalListenerRepl(this.consoleView, this.bootTidal, this.status, this.editor);
+        this.repl = new TidalListenerRepl(this.consoleView, this.status, this.editor);
       } else {
         this.ghc = new Ghc(this.consoleView);
         this.ghc.init();

--- a/lib/tidalcycles.js
+++ b/lib/tidalcycles.js
@@ -2,6 +2,7 @@
 
 import ConsoleView from './console-view';
 import Repl from './repl';
+import TidalListenerRepl from './tidal-listener-repl';
 import OscLoader from './osc-loader';
 import AutocompleteProvider from './autocomplete-provider';
 import Ghc from './ghc';
@@ -21,10 +22,15 @@ export default {
     activate() {
       this.consoleView = new ConsoleView(this.status);
       this.consoleView.initUI();
-      this.ghc = new Ghc(this.consoleView);
-      this.ghc.init();
-      this.bootTidal = new BootTidal(this.ghc, atom.project.rootDirectories);
-      this.repl = new Repl(this.consoleView, this.ghc, this.bootTidal, this.status, this.editor);
+
+      if (atom.config.get('tidalcycles.interpreter') === 'listener') {
+        this.repl = new TidalListenerRepl(this.consoleView, this.bootTidal, this.status, this.editor);
+      } else {
+        this.ghc = new Ghc(this.consoleView);
+        this.ghc.init();
+        this.bootTidal = new BootTidal(this.ghc, atom.project.rootDirectories);
+        this.repl = new Repl(this.consoleView, this.ghc, this.bootTidal, this.status, this.editor);
+      }
 
       if (atom.config.get('tidalcycles.oscEvalEnable')) {
         this.oscLoader = new OscLoader(this.consoleView, this.repl, this.editor);


### PR DESCRIPTION
As discussed in #157 .
Implemented a simple version where code evaluation is done through an instance of `tidal-listener` executed right into the editor.
There are some differences with the standard way of using this plugin (no `BootTidal.hs`, no `d1`, `d2`, etc...) but it's testable.