### PR TITLE
OSC tab change

### DIFF
--- a/lib/osc-loader.js
+++ b/lib/osc-loader.js
@@ -30,6 +30,10 @@ export default class OscLoader extends EventEmitter {
                     this.editors.goTo(resultDict['row'] - 1, resultDict['column'])
                 }
 
+                if (resultDict['tab']) {
+                    atom.workspace.getPanes()[0].setActiveItem(atom.workspace.getTextEditors()[resultDict['tab']])
+                }
+                
                 this.tidalRepl.eval(resultDict['type'], false);
             }
         });

--- a/lib/osc-loader.js
+++ b/lib/osc-loader.js
@@ -30,10 +30,10 @@ export default class OscLoader extends EventEmitter {
                     this.editors.goTo(resultDict['row'] - 1, resultDict['column'])
                 }
 
-                if (resultDict['tab']) {
+                if (resultDict['tab'] !== undefined) {
                     atom.workspace.getPanes()[0].setActiveItem(atom.workspace.getTextEditors()[resultDict['tab']])
                 }
-                
+
                 this.tidalRepl.eval(resultDict['type'], false);
             }
         });


### PR DESCRIPTION
With this PR it is possible to switch between different tabs with OSC. 
The `undefined` check is necessary to make the `tab` attribute optional.