### PR TITLE
Use <br> instead of \n to do line return

### DIFF
--- a/lib/console-view.js
+++ b/lib/console-view.js
@@ -64,7 +64,7 @@ export default class ConsoleView {
   }
 
   flushLog() {
-    let text = this.rows.join('\n')
+    let text = this.rows.join('<br>')
     this.rows = []
     this.logText(text)
   }


### PR DESCRIPTION
Noticed from [this console log](https://club.tidalcycles.org/t/something-has-gone-wrong-with-my-mac-install/3349/5?u=ndr_brt) that `\n` was not the right way to format console output. `<br>` should do the job better