### PR TITLE
Fix and utility for event hihglighting

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -156,10 +156,10 @@ export default {
         description: 'OSC Port where you expect to receive TidalCycles highlight events.',
         order: 110,
       },
-      'exceptedKeywords': {
+      'excludeKeywords': {
         type: 'array',
-        default: [],
-        title: 'Excepted Keywords',
+        default: ['putStr', 'putStrLn', 'setcps', 'getcps', 'getnow', 'hush'],
+        title: 'Exclude Keywords',
         description: 'Lines containing any of these keywords will be excluded from event highlighting metadata. E.g. putStr, putStrLn',
         order: 115,
         items: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -155,6 +155,16 @@ export default {
         default: 6013,
         description: 'OSC Port where you expect to receive TidalCycles highlight events.',
         order: 110,
+      },
+      'exceptedKeywords': {
+        type: 'array',
+        default: [],
+        title: 'Excepted Keywords',
+        description: 'Lines containing any of these keywords will be excluded from event highlighting metadata. E.g. putStr, putStrLn',
+        order: 115,
+        items: {
+          type: 'string'
+        }
       }
     }
   }

--- a/lib/event-highlighter.js
+++ b/lib/event-highlighter.js
@@ -71,9 +71,11 @@ export default class EventHighlighter {
 
     // Replace quoted segments with `(deltaContext …)` unless they belong to
     // known control‑pattern contexts.
+    const exceptedKeywords = atom.config.get('tidalcycles.eventHighlighting.exceptedKeywords');
     return line.replace(LineProcessor.controlPatternsRegex(), (match, content, offset) => {
       const before = line.slice(0, offset);
       if (LineProcessor.exceptedFunctionPatterns().test(before)) return match; // ignore control‑patterns
+      if (LineProcessor.isExceptedByKeywords(line, exceptedKeywords)) return match; // ignore user-defined keywords
 
       this.eventIds.push({
         rowStart: lineNumber,

--- a/lib/event-highlighter.js
+++ b/lib/event-highlighter.js
@@ -33,7 +33,7 @@ export default class EventHighlighter {
     this.addedThisFrame = new Set();       // Set<event>
     this.eventIds = [];                    // [{textbufferId, row}]
 
-    // Animation state -------------------------------------------------------
+    // Animation state -------------------------------------------------------
     this.then = 0; // time at previous frame
 
     // Bind instance methods used as callbacks -----------------------------
@@ -71,11 +71,10 @@ export default class EventHighlighter {
 
     // Replace quoted segments with `(deltaContext …)` unless they belong to
     // known control‑pattern contexts.
-    const exceptedKeywords = atom.config.get('tidalcycles.eventHighlighting.exceptedKeywords');
+    const excludeKeywords = atom.config.get('tidalcycles.eventHighlighting.excludeKeywords');
+    const excludedPattern = LineProcessor.excludedFunctionPatterns(excludeKeywords);
     return line.replace(LineProcessor.controlPatternsRegex(), (match, content, offset) => {
-      const before = line.slice(0, offset);
-      if (LineProcessor.exceptedFunctionPatterns().test(before)) return match; // ignore control‑patterns
-      if (LineProcessor.isExceptedByKeywords(line, exceptedKeywords)) return match; // ignore user-defined keywords
+      if (excludedPattern.test(line)) return match; // ignore excluded patterns and keywords
 
       this.eventIds.push({
         rowStart: lineNumber,

--- a/lib/line-processor.js
+++ b/lib/line-processor.js
@@ -63,7 +63,7 @@ export default class LineProcessor {
   }
 
   static exceptedFunctionPatterns() {
-    return /numerals\s*=.*$|p\s.*$/;
+    return /numerals\s*=.*$|p\s.*$|^\s*:/;
   }
 }
 

--- a/lib/line-processor.js
+++ b/lib/line-processor.js
@@ -62,13 +62,12 @@ export default class LineProcessor {
     return /"([^"]*)"/g;
   }
 
-  static exceptedFunctionPatterns() {
-    return /numerals\s*=.*$|p\s.*$|^\s*:/;
-  }
-
-  static isExceptedByKeywords(line, keywords) {
-    if (!keywords || keywords.length === 0) return false;
-    return keywords.some(kw => line.includes(kw));
+  static excludedFunctionPatterns(keywords = []) {
+    const base = /numerals\s*=.*$|p\s.*$|^\s*:/;
+    if (!keywords || keywords.length === 0) return base;
+    return {
+      test: (line) => base.test(line) || keywords.some(kw => line.includes(kw))
+    };
   }
 }
 

--- a/lib/line-processor.js
+++ b/lib/line-processor.js
@@ -65,5 +65,10 @@ export default class LineProcessor {
   static exceptedFunctionPatterns() {
     return /numerals\s*=.*$|p\s.*$|^\s*:/;
   }
+
+  static isExceptedByKeywords(line, keywords) {
+    if (!keywords || keywords.length === 0) return false;
+    return keywords.some(kw => line.includes(kw));
+  }
 }
 

--- a/spec/line-processor-spec.js
+++ b/spec/line-processor-spec.js
@@ -110,4 +110,27 @@ describe('Line Processor', () => {
     		expect(testString.match(LineProcessor.exceptedFunctionPatterns())).toBeNull()
     	})
     })
+
+    describe('isExceptedByKeywords', () => {
+        it('should return false when keywords list is empty', () => {
+            expect(LineProcessor.isExceptedByKeywords('d1 $ s "bd"', [])).toBe(false);
+        })
+
+        it('should return false when keywords is null or undefined', () => {
+            expect(LineProcessor.isExceptedByKeywords('d1 $ s "bd"', null)).toBe(false);
+            expect(LineProcessor.isExceptedByKeywords('d1 $ s "bd"', undefined)).toBe(false);
+        })
+
+        it('should return true when the line contains a configured keyword', () => {
+            expect(LineProcessor.isExceptedByKeywords('myCustomFn $ s "bd"', ['myCustomFn'])).toBe(true);
+        })
+
+        it('should return false when no keyword matches the line', () => {
+            expect(LineProcessor.isExceptedByKeywords('d1 $ s "bd"', ['myCustomFn', 'otherFn'])).toBe(false);
+        })
+
+        it('should return true when any one of multiple keywords matches', () => {
+            expect(LineProcessor.isExceptedByKeywords('d1 $ slow 2 $ s "bd"', ['fast', 'slow'])).toBe(true);
+        })
+    })
 })

--- a/spec/line-processor-spec.js
+++ b/spec/line-processor-spec.js
@@ -91,46 +91,49 @@ describe('Line Processor', () => {
     	})
     })
 
-    describe('exceptedFunctionPatterns', () => {
+    describe('excludedFunctionPatterns', () => {
         it ('should match numerals function occurance in a line', () => {
     		const testString = `numerals = "0 1 2 3"`;
     		const expected = 'numerals = "0 1 2 3"';
-    		expect(testString.match(LineProcessor.exceptedFunctionPatterns())[0]).toEqual(expected);
+    		expect(testString.match(LineProcessor.excludedFunctionPatterns())[0]).toEqual(expected);
     	})
 
         it ('should match p function occurance in a line', () => {
     		const testString = `p "hello" $ s "808"`;
     		const expected = 'p "hello" $ s "808"';
     
-    		expect(testString.match(LineProcessor.exceptedFunctionPatterns())[0]).toEqual(expected);
+    		expect(testString.match(LineProcessor.excludedFunctionPatterns())[0]).toEqual(expected);
     	})
 
         it ('should not match an allowed control pattern in a line', () => {
     		const testString = `d1 $ s "superpiano"`;
-    		expect(testString.match(LineProcessor.exceptedFunctionPatterns())).toBeNull()
+    		expect(testString.match(LineProcessor.excludedFunctionPatterns())).toBeNull()
     	})
-    })
 
-    describe('isExceptedByKeywords', () => {
-        it('should return false when keywords list is empty', () => {
-            expect(LineProcessor.isExceptedByKeywords('d1 $ s "bd"', [])).toBe(false);
+        it ('should match a line starting with : (interpreter command)', () => {
+    		const testString = `:set prompt ""`;
+    		expect(LineProcessor.excludedFunctionPatterns().test(testString)).toBe(true);
+    	})
+
+        it('should not exclude when keywords list is empty', () => {
+            expect(LineProcessor.excludedFunctionPatterns([]).test('d1 $ s "bd"')).toBe(false);
         })
 
-        it('should return false when keywords is null or undefined', () => {
-            expect(LineProcessor.isExceptedByKeywords('d1 $ s "bd"', null)).toBe(false);
-            expect(LineProcessor.isExceptedByKeywords('d1 $ s "bd"', undefined)).toBe(false);
+        it('should not exclude when keywords is null or undefined', () => {
+            expect(LineProcessor.excludedFunctionPatterns(null).test('d1 $ s "bd"')).toBe(false);
+            expect(LineProcessor.excludedFunctionPatterns(undefined).test('d1 $ s "bd"')).toBe(false);
         })
 
-        it('should return true when the line contains a configured keyword', () => {
-            expect(LineProcessor.isExceptedByKeywords('myCustomFn $ s "bd"', ['myCustomFn'])).toBe(true);
+        it('should exclude when the line contains a configured keyword', () => {
+            expect(LineProcessor.excludedFunctionPatterns(['myCustomFn']).test('myCustomFn $ s "bd"')).toBe(true);
         })
 
-        it('should return false when no keyword matches the line', () => {
-            expect(LineProcessor.isExceptedByKeywords('d1 $ s "bd"', ['myCustomFn', 'otherFn'])).toBe(false);
+        it('should not exclude when no keyword matches the line', () => {
+            expect(LineProcessor.excludedFunctionPatterns(['myCustomFn', 'otherFn']).test('d1 $ s "bd"')).toBe(false);
         })
 
-        it('should return true when any one of multiple keywords matches', () => {
-            expect(LineProcessor.isExceptedByKeywords('d1 $ slow 2 $ s "bd"', ['fast', 'slow'])).toBe(true);
+        it('should exclude when any one of multiple keywords matches', () => {
+            expect(LineProcessor.excludedFunctionPatterns(['fast', 'slow']).test('d1 $ slow 2 $ s "bd"')).toBe(true);
         })
     })
 })


### PR DESCRIPTION
This PR adds two features:

1. No lines of code starting with semicolons will be injected with metadata (these are GHCI command calls, the event highlighting currently breaks any of these commands)
2. Adds a menu section where one can add keywords to exclude lines from metadata injection. This is useful for any functions that print information (putStr or other custom functions users might use)