### PR TITLE
fix: don't add metadata to interpreter calls (lines with :)

### DIFF
--- a/lib/line-processor.js
+++ b/lib/line-processor.js
@@ -63,7 +63,7 @@ export default class LineProcessor {
   }
 
   static exceptedFunctionPatterns() {
-    return /numerals\s*=.*$|p\s.*$/;
+    return /numerals\s*=.*$|p\s.*$|^\s*:/;
   }
 }
 


### PR DESCRIPTION
While this was going to be handled in #238 ,, the scope of the PR had to be reduced as better solutions for some problems were found by @thgrund . For this reason I create this new PR which makes the simple change of avoiding any line starting with a colon, which is still an issue.

On line-processor:

before:
`return /numerals\s*=.*$|p\s.*$/;`

after:
`return /numerals\s*=.*$|p\s.*$|^\s*:/;`

Tested on my Win11 machine